### PR TITLE
Fix f-string syntax error in bodybuilding app

### DIFF
--- a/bodybuilding_app.py
+++ b/bodybuilding_app.py
@@ -3268,7 +3268,7 @@ def check_duplicate_users():
                             <td>{dup[0]}</td>
                             <td>{dup[1]}</td>
                             <td>{dup[2]}</td>
-                            <td class="password-cell">{dup[3][:50]}...</td>
+                            <td class="password-cell">{str(dup[3])[:50]}...</td>
                             <td>{dup[4]}</td>
                             <td>{dup[5]}</td>
                             <td>
@@ -3308,7 +3308,7 @@ def check_duplicate_users():
                             <td>{record[0]}</td>
                             <td>{record[1]}</td>
                             <td>{record[2] or 'N/A'}</td>
-                            <td class="password-cell">{record[3][:30] if record[3] else 'N/A'}...</td>
+                            <td class="password-cell">{str(record[3])[:30] if record[3] else 'N/A'}...</td>
                             <td>{record[4] or 'N/A'}</td>
                             <td>{record[5] or 'N/A'}</td>
                         </tr>


### PR DESCRIPTION
Fix f-string `SyntaxError: unmatched '['` by explicitly converting sliced elements to string.

The Python f-string parser was encountering a `SyntaxError` when slice notation (e.g., `[:50]`) was applied directly to list or tuple elements within the f-string's curly braces. Explicitly converting these elements to `str()` before slicing ensures the operation is performed on a string, resolving the parser's confusion.

---
<a href="https://cursor.com/background-agent?bcId=bc-9927230a-1579-433e-841b-bbd440533096">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9927230a-1579-433e-841b-bbd440533096">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

