### PR TITLE
Add picture reply to post detail

### DIFF
--- a/client/src/pages/PostDetail.tsx
+++ b/client/src/pages/PostDetail.tsx
@@ -258,16 +258,21 @@ export default function PostDetail(){
           {(composerActive || !!content || !!file) ? (
             <div className="flex items-center justify-end gap-2 flex-wrap">
               {file && (
-                <div className="text-xs text-[#7fe7df] flex items-center gap-1">
-                  <i className="fa-solid fa-image" />
-                  <span>{file.name}</span>
-                  <button 
-                    onClick={() => setFile(null)}
-                    className="ml-1 text-red-400 hover:text-red-300"
-                    aria-label="Remove file"
-                  >
-                    <i className="fa-solid fa-times" />
-                  </button>
+                <div className="flex items-center gap-2 mr-auto">
+                  <div className="w-16 h-16 rounded-md overflow-hidden border border-white/10">
+                    <img src={URL.createObjectURL(file)} alt="preview" className="w-full h-full object-cover" />
+                  </div>
+                  <div className="text-xs text-[#7fe7df] flex items-center gap-1">
+                    <i className="fa-solid fa-image" />
+                    <span className="max-w-[160px] truncate">{file.name}</span>
+                    <button 
+                      onClick={() => { setFile(null); if (fileInputRef.current) fileInputRef.current.value = '' }}
+                      className="ml-1 text-red-400 hover:text-red-300"
+                      aria-label="Remove file"
+                    >
+                      <i className="fa-solid fa-times" />
+                    </button>
+                  </div>
                 </div>
               )}
               <label className="relative inline-flex items-center justify-center w-10 h-10 rounded-full hover:bg-white/10 cursor-pointer" aria-label="Add image">


### PR DESCRIPTION
Add image preview and input clearing for picture replies in PostDetail.tsx.

---
<a href="https://cursor.com/background-agent?bcId=bc-a07c5aa5-1c7b-4315-86db-d8a6b7a0e6f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a07c5aa5-1c7b-4315-86db-d8a6b7a0e6f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

