### PR TITLE
fix(ios): bridge APNs registration to Capacitor push notifications

### DIFF
--- a/client/ios/App/App/AppDelegate.swift
+++ b/client/ios/App/App/AppDelegate.swift
@@ -101,6 +101,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // MARK: - APNs Token Registration
 
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        // Required by @capacitor/push-notifications (enables removeAllDeliveredNotifications, etc.)
+        NotificationCenter.default.post(name: .capacitorDidRegisterForRemoteNotifications, object: deviceToken)
+
         let tokenString = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
         
         NSLog("🟢🟢🟢 APNS TOKEN RECEIVED 🟢🟢🟢")
@@ -118,6 +121,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        NotificationCenter.default.post(name: .capacitorDidFailToRegisterForRemoteNotifications, object: error)
+
         NSLog("🔴🔴🔴 APNS REGISTRATION FAILED 🔴🔴🔴")
         NSLog("Error: %@", error.localizedDescription)
         print("❌ Failed to register for remote notifications!")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The app uses a custom `AppDelegate` that implements `application(_:didRegisterForRemoteNotificationsWithDeviceToken:)` for Firebase/APNs, but it never notified Capacitor. The `@capacitor/push-notifications` plugin only marks iOS as "registered" when it receives `Notification.Name.capacitorDidRegisterForRemoteNotifications` (see [Capacitor docs](https://capacitorjs.com/docs/apis/push-notifications#ios)).

Without that notification, calls like `PushNotifications.removeAllDeliveredNotifications()` (used from `BadgeContext` on poll/resume) fail with: `event capacitorDidRegisterForRemoteNotifications not called`.

## Change

Post Capacitor's registration notifications from `AppDelegate` at the start of the success and failure handlers, preserving existing Firebase and direct server token logic.

## After merge

Rebuild the iOS app in Xcode (or `npx cap sync ios` then build). Simulator may still not deliver a real APNs token; the plugin will at least receive the failure notification path when registration fails.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-437003e8-7764-4e12-aa12-f2f4beaae5eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-437003e8-7764-4e12-aa12-f2f4beaae5eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

