### PR TITLE
fix(ios): reduce share extension console noise from NSItemProvider

### DIFF
--- a/client/ios/App/ShareExtension/ShareViewController.swift
+++ b/client/ios/App/ShareExtension/ShareViewController.swift
@@ -174,9 +174,11 @@ final class ShareViewController: UIViewController {
     }
 
     private func loadFileURL(provider: NSItemProvider, incoming: URL, indexBox: IndexBox) async -> [[String: Any]]? {
+        // Prefer loadFileRepresentation over loadItem — the latter triggers noisy
+        // system logs ("nil expectedValueClass allowing …") and is less predictable for file URLs.
         await withCheckedContinuation { (cont: CheckedContinuation<[[String: Any]]?, Never>) in
-            provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier, options: nil) { item, err in
-                guard let url = item as? URL, err == nil else {
+            provider.loadFileRepresentation(forTypeIdentifier: UTType.fileURL.identifier) { url, err in
+                guard let url = url, err == nil else {
                     cont.resume(returning: nil)
                     return
                 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What you saw

The log line mentioning `_EXSinkLoadOperator` and `nil expectedValueClass allowing { … }` comes from the system when `NSItemProvider.loadItem(forTypeIdentifier:options:)` is used without an expected class. It is usually **informational**, not a crash.

## Change

`ShareViewController.loadFileURL` now uses `loadFileRepresentation(forTypeIdentifier:)` (same pattern as image/video loading) instead of `loadItem`, which avoids that code path and is appropriate when we only need a temporary file URL to copy into the app group.

## Testing

Share a file-backed image or video into the extension from Files / Photos and confirm the host app still receives the manifest as before.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-437003e8-7764-4e12-aa12-f2f4beaae5eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-437003e8-7764-4e12-aa12-f2f4beaae5eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

