### PR TITLE
fix(entitlements): per-tier member caps + honor KB community limits

### DIFF
--- a/backend/services/entitlements.py
+++ b/backend/services/entitlements.py
@@ -84,6 +84,14 @@ _DEFAULTS: Dict[str, Any] = {
     "free_communities_max": 5,
     "premium_communities_max": 10,
     "trial_communities_max": 5,
+    # Tier-specific member caps. The KB defines these per-tier
+    # (``free_members_per_owned_community`` / ``premium_members_per_owned_community``);
+    # Trial inherits the Free cap (documented policy — trial communities that
+    # overshoot Free limits lock read-only on trial lapse).
+    "free_members_per_owned_community": 50,
+    "premium_members_per_owned_community": 50,
+    # Legacy generic key preserved for any caller still reading it; new code
+    # should use the tier-specific keys above.
     "members_per_owned_community": 50,
 }
 
@@ -143,10 +151,27 @@ def _load_kb_defaults() -> Dict[str, Any]:
     except Exception:
         out["monthly_spend_ceiling_eur_special"] = _DEFAULTS["monthly_spend_ceiling_eur_special"]
 
-    # User Tiers
-    for k in ("free_communities_max", "premium_communities_max",
-              "trial_communities_max", "members_per_owned_community"):
+    # User Tiers — community-count caps and tier-specific member caps.
+    # The KB exposes these as separate fields (``free_members_per_owned_community``
+    # and ``premium_members_per_owned_community``); admin edits must flow
+    # through at request time so pricing changes don't need a redeploy.
+    for k in (
+        "free_communities_max",
+        "premium_communities_max",
+        "trial_communities_max",
+        "free_members_per_owned_community",
+        "premium_members_per_owned_community",
+    ):
         out[k] = int(_kb_field_value("user-tiers", k, _DEFAULTS[k]) or _DEFAULTS[k])
+
+    # Back-compat: old generic key. Prefer the KB's generic value if set,
+    # else fall back to the Premium tier value so any legacy caller still
+    # gets a sensible number.
+    legacy_generic = _kb_field_value("user-tiers", "members_per_owned_community", None)
+    try:
+        out["members_per_owned_community"] = int(legacy_generic) if legacy_generic is not None else out["premium_members_per_owned_community"]
+    except Exception:
+        out["members_per_owned_community"] = out["premium_members_per_owned_community"]
 
     return out
 
@@ -314,7 +339,7 @@ def resolve_entitlements(username: Optional[str]) -> Dict[str, Any]:
             "steve_uses_per_month": defaults["steve_uses_per_month"],
             "whisper_minutes_per_month": defaults["whisper_minutes_per_month"],
             "communities_max": defaults["premium_communities_max"],
-            "members_per_owned_community": defaults["members_per_owned_community"],
+            "members_per_owned_community": defaults["premium_members_per_owned_community"],
             "ai_daily_limit": defaults["ai_daily_limit"],
             "max_tool_invocations_per_turn": defaults["max_tool_invocations_per_turn"],
             "monthly_spend_ceiling_eur": defaults["monthly_spend_ceiling_eur"],
@@ -328,7 +353,9 @@ def resolve_entitlements(username: Optional[str]) -> Dict[str, Any]:
             "steve_uses_per_month": defaults["steve_uses_per_month"],
             "whisper_minutes_per_month": defaults["whisper_minutes_per_month"],
             "communities_max": defaults["trial_communities_max"],
-            "members_per_owned_community": defaults["members_per_owned_community"],
+            # Trial inherits the Free member cap by design — trial
+            # communities that overshoot Free limits lock read-only on lapse.
+            "members_per_owned_community": defaults["free_members_per_owned_community"],
             "ai_daily_limit": defaults["ai_daily_limit"],
             "max_tool_invocations_per_turn": defaults["max_tool_invocations_per_turn"],
             "monthly_spend_ceiling_eur": defaults["monthly_spend_ceiling_eur"],
@@ -342,7 +369,7 @@ def resolve_entitlements(username: Optional[str]) -> Dict[str, Any]:
             "steve_uses_per_month": 0,
             "whisper_minutes_per_month": 0,
             "communities_max": defaults["free_communities_max"],
-            "members_per_owned_community": defaults["members_per_owned_community"],
+            "members_per_owned_community": defaults["free_members_per_owned_community"],
             "ai_daily_limit": 0,
             "max_tool_invocations_per_turn": defaults["max_tool_invocations_per_turn"],
             "monthly_spend_ceiling_eur": 0.0,

--- a/backend/services/knowledge_base.py
+++ b/backend/services/knowledge_base.py
@@ -1518,6 +1518,15 @@ def _seed_pages() -> List[Dict[str, Any]]:
                             "last_run_at": "", "last_run_by": "", "last_run_notes": "",
                         },
                         {
+                            "id": "entitlements:per_tier_member_caps",
+                            "feature": "User Tiers — per-tier community & member caps",
+                            "behaviour": "resolve_entitlements() reads free_/premium_members_per_owned_community from the KB and applies them per tier (Trial inherits Free; Special is unlimited). Locks the bug where Free users were capped at 100 members / 2 communities regardless of KB.",
+                            "runner": "pytest",
+                            "target": "tests/test_entitlements_resolve.py::TestPerTierMemberCaps",
+                            "status": "not_run",
+                            "last_run_at": "", "last_run_by": "", "last_run_notes": "",
+                        },
+                        {
                             "id": "staging:webhooks_not_401",
                             "feature": "Stripe / Apple / Google webhooks",
                             "behaviour": "Webhook endpoints reject unsigned requests with 400 (not 401 from session middleware).",

--- a/bodybuilding_app.py
+++ b/bodybuilding_app.py
@@ -1866,8 +1866,25 @@ def ensure_free_parent_member_capacity(cursor, community_id: Optional[int], extr
         current_count = int(current_count or 0)
     except Exception:
         current_count = 0
-    if current_count + extra_members > 100:
-        raise CommunityMembershipLimitError('Free plan communities can have up to 100 members. Upgrade to add more members.')
+    # Read the Free-tier per-community member cap from entitlements (KB-driven).
+    # Fail closed on resolver error to a safe legacy cap of 100 so we never
+    # uncap a free community because the KB is temporarily broken.
+    free_members_cap = 100
+    try:
+        from backend.services.entitlements import resolve_entitlements as _resolve_ent
+        _ent = _resolve_ent(creator_username) or {}
+        _cap = _ent.get("members_per_owned_community")
+        if isinstance(_cap, int) and _cap > 0:
+            free_members_cap = _cap
+    except Exception:
+        logger.exception(
+            "ensure_free_parent_member_capacity: resolve_entitlements failed for %s",
+            creator_username,
+        )
+    if current_count + extra_members > free_members_cap:
+        raise CommunityMembershipLimitError(
+            f'Free plan communities can have up to {free_members_cap} members. Upgrade to add more members.'
+        )
 
 
 # ============================================================================
@@ -28537,8 +28554,20 @@ def create_community():
                         parent_count = int(parent_count)
                     except Exception:
                         parent_count = 0
-                    if parent_count >= 2:
-                        return jsonify({'success': False, 'error': 'Free plan allows up to 2 parent communities. Upgrade to create more communities.'}), 403
+                    # Read the Free-tier cap from entitlements (KB-driven).
+                    # Falls back to the historical cap of 2 if the resolver blows up,
+                    # so we never fail-open on a broken KB.
+                    free_communities_cap = 2
+                    try:
+                        from backend.services.entitlements import resolve_entitlements as _resolve_ent
+                        _ent = _resolve_ent(username) or {}
+                        _cap = _ent.get("communities_max")
+                        if isinstance(_cap, int) and _cap > 0:
+                            free_communities_cap = _cap
+                    except Exception:
+                        logger.exception("create_community: resolve_entitlements failed for %s", username)
+                    if parent_count >= free_communities_cap:
+                        return jsonify({'success': False, 'error': f'Free plan allows up to {free_communities_cap} parent communities. Upgrade to create more communities.'}), 403
                 else:
                     parent_info = get_community_basic(c, parent_id_int)
                     if not parent_info:

--- a/tests/test_entitlements_resolve.py
+++ b/tests/test_entitlements_resolve.py
@@ -212,6 +212,129 @@ class TestKBDrivenConfiguration:
         assert resolve_entitlements("special_u")["ai_daily_limit"] == 200
 
 
+# ── 4b. Per-tier community / member caps ────────────────────────────────
+
+
+class TestPerTierMemberCaps:
+    """The Free and Premium tiers expose *different* per-community member
+    caps via separate KB fields (``free_members_per_owned_community`` vs
+    ``premium_members_per_owned_community``). A previous bug looked up a
+    single generic ``members_per_owned_community`` field instead, so admin
+    edits to the tier-specific KB fields silently fell back to the bundled
+    default of 50 regardless of tier. These tests lock down the fix.
+    """
+
+    def test_free_member_cap_reads_from_kb_free_field(self, mysql_dsn):
+        from tests.fixtures import seed_kb
+        seed_kb([
+            {
+                "slug": "user-tiers",
+                "title": "User Tiers",
+                "category": "product",
+                "fields": [
+                    {"name": "free_communities_max", "type": "integer",
+                     "label": "free_communities_max", "value": 5},
+                    {"name": "free_members_per_owned_community", "type": "integer",
+                     "label": "free_members_per_owned_community", "value": 25},
+                    {"name": "premium_members_per_owned_community", "type": "integer",
+                     "label": "premium_members_per_owned_community", "value": 50},
+                ],
+            },
+        ])
+        make_user("free_user", subscription="free", created_at=days_ago(60))
+        ent = resolve_entitlements("free_user")
+        assert ent["tier"] == TIER_FREE
+        # The value the user reported in the bug: Free cap = 25 from the KB.
+        assert ent["members_per_owned_community"] == 25
+
+    def test_premium_member_cap_reads_from_kb_premium_field(self, mysql_dsn):
+        from tests.fixtures import seed_kb
+        seed_kb([
+            {
+                "slug": "user-tiers",
+                "title": "User Tiers",
+                "category": "product",
+                "fields": [
+                    {"name": "free_members_per_owned_community", "type": "integer",
+                     "label": "free_members_per_owned_community", "value": 25},
+                    {"name": "premium_members_per_owned_community", "type": "integer",
+                     "label": "premium_members_per_owned_community", "value": 200},
+                ],
+            },
+        ])
+        make_user("paying", subscription="premium", created_at=days_ago(30))
+        ent = resolve_entitlements("paying")
+        assert ent["tier"] == TIER_PREMIUM
+        # Premium admin-set cap must flow through — independent of Free's cap.
+        assert ent["members_per_owned_community"] == 200
+
+    def test_trial_inherits_free_member_cap(self, mysql_dsn):
+        """Documented policy: trial communities that overshoot Free limits
+        lock read-only on trial lapse, so the trial member cap tracks Free."""
+        from tests.fixtures import seed_kb
+        seed_kb([
+            {
+                "slug": "user-tiers",
+                "title": "User Tiers",
+                "category": "product",
+                "fields": [
+                    {"name": "free_members_per_owned_community", "type": "integer",
+                     "label": "free_members_per_owned_community", "value": 25},
+                    {"name": "premium_members_per_owned_community", "type": "integer",
+                     "label": "premium_members_per_owned_community", "value": 200},
+                ],
+            },
+        ])
+        make_user("trial_user", subscription="free", created_at=days_ago(5))
+        ent = resolve_entitlements("trial_user")
+        assert ent["tier"] == TIER_TRIAL
+        assert ent["members_per_owned_community"] == 25
+
+    def test_free_communities_max_reads_from_kb(self, mysql_dsn):
+        """The Free-tier community-count cap is the count limit the
+        ``/create_community`` route enforces. Admin must be able to raise
+        it from 2 to 5 (or any value) via the KB without a redeploy."""
+        from tests.fixtures import seed_kb
+        seed_kb([
+            {
+                "slug": "user-tiers",
+                "title": "User Tiers",
+                "category": "product",
+                "fields": [
+                    {"name": "free_communities_max", "type": "integer",
+                     "label": "free_communities_max", "value": 5},
+                ],
+            },
+        ])
+        make_user("free_user", subscription="free", created_at=days_ago(60))
+        ent = resolve_entitlements("free_user")
+        assert ent["tier"] == TIER_FREE
+        assert ent["communities_max"] == 5
+
+    def test_special_user_member_cap_is_unlimited(self, mysql_dsn):
+        """Special users get unlimited member caps (represented as None).
+        KB edits to Free/Premium caps must not leak into Special."""
+        from tests.fixtures import seed_kb
+        seed_kb([
+            {
+                "slug": "user-tiers",
+                "title": "User Tiers",
+                "category": "product",
+                "fields": [
+                    {"name": "free_members_per_owned_community", "type": "integer",
+                     "label": "free_members_per_owned_community", "value": 25},
+                    {"name": "premium_members_per_owned_community", "type": "integer",
+                     "label": "premium_members_per_owned_community", "value": 200},
+                ],
+            },
+        ])
+        make_user("founder", subscription="free", is_special=True,
+                  created_at=days_ago(400))
+        ent = resolve_entitlements("founder")
+        assert ent["tier"] == TIER_SPECIAL
+        assert ent["members_per_owned_community"] is None
+
+
 # ── 5. Cross-cutting invariants ─────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Free users were silently capped at 2 communities / 100 members regardless of KB settings because of three independent bugs:

- ackend/services/entitlements.py looked up a single generic `members_per_owned_community` KB field, but the KB defines `free_members_per_owned_community` and `premium_members_per_owned_community` as separate fields. Admin edits silently fell back to the bundled default of 50; Free vs Premium caps were always identical.
- odybuilding_app.py:create_community() hardcoded `parent_count >= 2` for Free users, ignoring `free_communities_max` in the KB.
- odybuilding_app.py:ensure_free_parent_member_capacity() hardcoded `> 100`, ignoring the KB.

Both call sites now resolve caps via `resolve_entitlements(user)` with fail-closed fallback to the historical cap if the resolver raises, so a broken KB can't uncap a Free community.

Trial users explicitly inherit the Free member cap now (documented lapse policy - trial communities that overshoot Free limits lock read-only on lapse).

## Test plan

- Adds `TestPerTierMemberCaps` (5 tests) in `tests/test_entitlements_resolve.py`:
  - Free user reads `free_members_per_owned_community` from KB
  - Premium user reads `premium_members_per_owned_community` from KB
  - Trial inherits Free member cap
  - Special stays unlimited (`None`) regardless of KB
  - `free_communities_max` flows through to `communities_max`
- New Tests-page row `entitlements:per_tier_member_caps` in `knowledge_base.py` so the admin dashboard surfaces this contract.

## Deployment status

- Staging: deployed at revision `cpoint-app-staging-00639-rcx` (build 947d266e), `/health` green, `/api/me/entitlements` responds.
- Production: pending this merge.